### PR TITLE
Refactor train command async submission

### DIFF
--- a/src/NepTrain/core/train/worker.py
+++ b/src/NepTrain/core/train/worker.py
@@ -2,51 +2,51 @@ import asyncio
 
 from dpdispatcher import Machine, Resources, Task, Submission
 from pathlib import Path
-def remove_sub_file(work_path="./"):
+
+
+def remove_sub_file(work_path: str = "./"):
+    """Remove temporary submission files."""
     all_file = Path(work_path).glob("????????????????????????????????????????.sub.*")
-
     for file in all_file:
-
         file.unlink()
-def submit_job( machine_dict,
-                resources_dict,
-                task_dict_list,
-                submission_dict
-               ):
+
+
+def submit_job(
+    machine_dict: dict,
+    resources_dict: dict,
+    task_dict_list: list,
+    submission_dict: dict,
+) -> Submission:
+    """Submit a job synchronously using dpdispatcher."""
     machine = Machine.load_from_dict(machine_dict)
     resources = Resources.load_from_dict(resources_dict)
-    task_list=[]
-    for task_dict in task_dict_list:
-        task1 = Task(**task_dict)
-        task_list.append(task1)
+    task_list = [Task(**task_dict) for task_dict in task_dict_list]
     submission = Submission(
         machine=machine,
         resources=resources,
-        task_list=task_list,**submission_dict
+        task_list=task_list,
+        **submission_dict,
     )
     submission.run_submission(clean=True)
     remove_sub_file()
     return submission
 
-async def async_submit_job( machine_dict,
-                resources_dict,
-                task_dict_list,
-                submission_dict
-               ):
+
+async def async_submit_job(
+    machine_dict: dict,
+    resources_dict: dict,
+    task_dict_list: list,
+    submission_dict: dict,
+) -> None:
+    """Submit a job asynchronously using dpdispatcher."""
     machine = Machine.load_from_dict(machine_dict)
     resources = Resources.load_from_dict(resources_dict)
-    task_list=[]
-    for task_dict in task_dict_list:
-        task1 = Task(**task_dict)
-        task_list.append(task1)
+    task_list = [Task(**task_dict) for task_dict in task_dict_list]
     submission = Submission(
         machine=machine,
         resources=resources,
-        task_list=task_list,**submission_dict
+        task_list=task_list,
+        **submission_dict,
     )
-    submission.async_run_submission(clean=True)
-    background_task = asyncio.create_task(
-
-    submission.async_run_submission(check_interval=2, clean=False)
- )
-    return background_task
+    await submission.async_run_submission(check_interval=2, clean=True)
+    remove_sub_file()


### PR DESCRIPTION
## Summary
- switch worker module to provide async submission helpers
- update train runner to use dpdispatcher async jobs for `vasp` and `gpumd`
- run select step locally via subprocess
- adjust imports for asyncio

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685fabd446d8832e82245de28d8509c4