### PR TITLE
Add submission and progress logs

### DIFF
--- a/src/NepTrain/core/train/run.py
+++ b/src/NepTrain/core/train/run.py
@@ -650,7 +650,8 @@ class NepTrainWorker:
         while True:
 
             #开始循环
-            job=next(self.manager)
+            job = next(self.manager)
+            utils.print_msg(f"[Generation {self.generation}] Starting job: {job}")
             self.config["current_job"]=job
             self.save_restart()
             if job=="vasp":
@@ -673,6 +674,8 @@ class NepTrainWorker:
 
             else:
                 self.sub_gpumd()
+
+            utils.print_msg(f"[Generation {self.generation}] Finished job: {job}")
 
 
     def save_restart(self):

--- a/src/NepTrain/core/train/worker.py
+++ b/src/NepTrain/core/train/worker.py
@@ -3,6 +3,7 @@ import os
 
 from dpdispatcher import Machine, Resources, Task, Submission
 from pathlib import Path
+from NepTrain import utils
 
 
 def remove_sub_file(work_path: str = "./"):
@@ -31,6 +32,9 @@ def submit_job(
         **submission_dict,
     )
     submission.run_submission(clean=False)
+    job_id = getattr(submission, 'job_id', getattr(submission, 'submission_id', 'UNKNOWN'))
+    work_path = getattr(submission, 'work_base', submission_dict.get('work_base', './'))
+    utils.print_msg(f"Submitted job {job_id} in {work_path}")
     remove_sub_file()
     return submission
 
@@ -52,4 +56,7 @@ async def async_submit_job(
         **submission_dict,
     )
     await submission.async_run_submission(check_interval=2, clean=False)
+    job_id = getattr(submission, 'job_id', getattr(submission, 'submission_id', 'UNKNOWN'))
+    work_path = getattr(submission, 'work_base', submission_dict.get('work_base', './'))
+    utils.print_msg(f"Submitted job {job_id} in {work_path}")
     remove_sub_file()


### PR DESCRIPTION
## Summary
- print job id and path after calling `submit_job`
- show progress messages during training lifecycle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860acc8ee1c832e85468a5473da4be5