### PR TITLE
docs: clarify command usage and outputs

### DIFF
--- a/docs/source/command/dft.md
+++ b/docs/source/command/dft.md
@@ -1,0 +1,45 @@
+# dft
+**Description:**
+Calculates single-point energies using external DFT programs such as VASP or ABACUS.
+
+## Input Parameters
+**Usage:**
+```bash
+NepTrain dft <model_path> [options]
+```
+**Options:**
+- `<model_path>`
+  Structure path or file (supports `xyz` and `vasp` formats).
+- `-dir, --directory`
+  Directory for DFT calculations. Default: `./cache/<software>`.
+- `-o, --out`
+  Output file path for calculated structure. Default: `./<software>_scf.xyz`.
+- `-a, --append`
+  Append to output file. Default: `False`.
+- `-g, --gamma`
+  Use Gamma-centered k-point scheme. Default: `False`.
+- `-n, -np`
+  Number of CPU cores. Default: `1`.
+- `--in`
+  Path to INCAR/INPUT file. Default: `./INCAR` for VASP, `./INPUT` for ABACUS.
+- `-kspacing, --kspacing`
+  Set k-spacing value.
+- `-ka`
+  Set k-points as 1 or 3 numbers (comma-separated). Default: `[1, 1, 1]`.
+- `--vasp`
+  Use VASP for the calculation (default).
+- `--abacus`
+  Use ABACUS for the calculation.
+
+## Output
+The selected DFT program is invoked to perform single-point energy calculations. Results and standard output are stored in `--directory` (default `./cache/<software>`). Processed structures are written to the file specified by `--out`.
+
+## Example
+To calculate single-point energies for all structures in the `structure` folder using the default VASP backend:
+```shell
+NepTrain dft structure -g
+```
+To run the same task with ABACUS and a custom input template:
+```shell
+NepTrain dft structure --abacus --in ./INPUT
+```

--- a/docs/source/command/gpumd.md
+++ b/docs/source/command/gpumd.md
@@ -23,17 +23,13 @@ If the filenames are incorrect, please specify them using the appropriate parame
   Path to potential function file. Default: `./nep.txt`.
 - `-t, --time`  
   Molecular dynamics simulation time (ps). Default: `10`.
-- `-T, --temperature`  
+- `-T, --temperature`
   Simulation temperature(s) (K). Default: `300`.
-- `-f, --filter`  
-  Whether to filter based on minimum bond length. Default: `True`.
-- `-o, --out`  
+- `-o, --out`
   Output file for trajectory. Default: `./trajectory.xyz`.
 
 ## Output
-GPUMD will output files in the `directory` (default is `./cache/gpumd`). In addition to GPUMD's standard output files, we also generate an energy vs. step plot, `md_energy.png`.  
-
-If the `filter` option is enabled, an additional file containing filtered-out nonphysical structures, `remove_by_bond_structures.xyz`, will also be generated.
+GPUMD will output files in the `directory` (default is `./cache/gpumd`) along with GPUMD's standard output files. The resulting trajectories are saved to the path specified by `--out`.
 
 
 

--- a/docs/source/command/index.rst
+++ b/docs/source/command/index.rst
@@ -9,6 +9,7 @@ Commands Guide
    gpumd      <gpumd.md>
    select     <select.md>
    vasp       <vasp.md>
+   dft        <dft.md>
    perturb    <perturb.md>
    init       <init.md>
    train      <train.md>

--- a/docs/source/command/init.md
+++ b/docs/source/command/init.md
@@ -5,11 +5,13 @@ Initializes file templates for NepTrain.
 
 **Usage:**  
 ```bash
-NepTrain init [-f]
+NepTrain init <type> [-f]
 ```
 
-**Options:**  
-- `-f, --force`  
+**Options:**
+- `<type>`
+  Job scheduler type. Choices: `bohrium`, `slurm`, `pbs`, `shell`. Default: `slurm`.
+- `-f, --force`
   Force overwriting of generated templates. Default: `False`.
 
 ## Output
@@ -22,22 +24,21 @@ These output files serve as inputs for the `train` command. Detailed modificatio
 - `run.in`  
   The template file for molecular dynamics (MD).  
 
-- `structure/`  
-  This folder must contain the structures required for active learning. Multiple structures can be included, and the file format should be either `.xyz` or `.vasp`.  
-
-- `sub_gpu.sh`  
-  A script file for submitting NEP and GPUMD tasks. <span style="color:red;">Modify the queue information based on your cluster setup.</span>  
-
-- `sub_vasp.sh`  
-  A script file for submitting VASP tasks. <span style="color:red;">Modify the queue information based on your cluster setup. </span> 
-### 可选的模板文件 
+- `structure/`
+  This folder must contain the structures required for active learning. Multiple structures can be included, and the file format should be either `.xyz` or `.vasp`.
+### 可选的模板文件
 - INCAR
-用户可以通过`INCAR`文件指定单点能的计算细节。如果没有指定则使用默认的INCAR。默认INCAR细节详见[INCAR](./vasp.md#default-incar)
+用户可以通过`INCAR`文件指定单点能的计算细节。如果没有指定则使用默认的INCAR。默认INCAR细节详见[INCAR](vasp.md)
 - nep.in
 如果没有指定该文件，会根据训练集自动判断元素种类，生成最简的nep.in。如果需要修改训练超参数，请自行创建该文件。
-最简的nep.in如下
-  ```text
-    generation     100000
-    type     3 I Cs Pb
-    ```
+  最简的nep.in如下
+    ```text
+      generation     100000
+      type     3 I Cs Pb
+      ```
 ## 文件修改
+生成的模板文件可以根据实际环境进行修改：
+
+- 根据训练需求编辑 `job.yaml` 中的参数。
+- 如需自定义训练超参数，可手动修改或创建 `nep.in`。
+

--- a/docs/source/command/nep.md
+++ b/docs/source/command/nep.md
@@ -19,12 +19,30 @@ NepTrain nep [options]
   Path to `test.xyz` file. Default: `./test.xyz`.
 - `-nep, --nep`  
   Path to potential function file. Default: `./nep.txt`.
-- `-pred, --prediction`  
+- `-pred, --prediction, --pred`
   Enable prediction mode. Default: `False`.
-- `-restart, --restart_file`  
+- `-restart, --restart_file, --restart`
   Path to restart file. Default: `None`.
-- `-cs, --continue_step`  
+- `-cs, --continue_step`
   Steps to continue from restart. Default: `10000`.
 ## Output
+Training results are written to the directory specified by `--directory`
+(default `./cache/nep`). Important files include:
 
- 
+- `nep.txt` – trained potential function.
+- `loss.out` – training loss for each step.
+- `nep.out` / `nep.err` – standard output and error logs.
+- `nep_result.png` – plot of the training loss.
+
+## Example
+Run NEP training with explicit training and testing datasets:
+
+```bash
+NepTrain nep --train train.xyz --test test.xyz
+```
+
+Resume training from a restart file for an additional 50,000 steps:
+
+```bash
+NepTrain nep --restart_file ./cache/nep/nep.restart --continue_step 50000
+```

--- a/docs/source/command/perturb.md
+++ b/docs/source/command/perturb.md
@@ -15,12 +15,21 @@ NepTrain perturb <model_path> [options]
   Number of perturbations for each structure. Default: `20`.
 - `-c, --cell`  
   Deformation ratio. Default: `0.03`.
-- `-d, --distance`  
-  Maximum atom distance (Å). Default: `0.1`.
-- `-o, --out`  
+- `-d, --distance`
+  Minimum atom distance (Å). Default: `0.1`.
+- `-o, --out`
   Output file path for perturbed structures. Default: `./perturb.xyz`.
-- `-a, --append`  
+- `-a, --append`
   Append to output file instead of overwriting. Default: `False`.
-- `-f, --filter`  
-  Filter structures based on minimum bond length. Default: `False`.
 ## Output
+All generated structures are written to the file specified by `--out`
+(default `./perturb.xyz`). When `--append` is used, new structures are
+appended to the existing file instead of overwriting it.
+
+## Example
+Generate 2000 perturbed configurations of a VASP structure file with a
+cell distortion of `0.03` and a minimum atomic distance of `0.1 Å`:
+
+```bash
+NepTrain perturb ./structure/Cs16Ag8Bi8I48.vasp --num 2000 --cell 0.03 -d 0.1
+```

--- a/docs/source/command/select.md
+++ b/docs/source/command/select.md
@@ -3,33 +3,50 @@
 Selects samples from trajectory files.
 ## Input Parameters
 
-**Usage:**  
+**Usage:**
 ```bash
-NepTrain select <trajectory_path> [options]
+NepTrain select <trajectory_paths> [options]
 ```
 
-**Options:**  
-- `<trajectory_path>`  
-  Path to trajectory file (xyz format).
-- `-base, --base`  
-  Path to `base.xyz` for sampling. Default: `base`.
+**Options:**
+- `<trajectory_paths>`
+  One or more trajectory files (xyz format).
+- `-base, --base`
+  Path to `base.xyz` for sampling. Default: `train.xyz`.
 - `-nep, --nep`  
   Path to `nep.txt` file for descriptor extraction. Default: `./nep.txt`.
-- `-max, --max_selected`  
+- `-max, --max_selected`
   Maximum number of structures to select. Default: `20`.
-- `-d, --min_distance`  
+- `-d, --min_distance`
   Minimum bond length for farthest-point sampling. Default: `0.01`.
-- `--pca, -pca`  
+- `-f, --filter [COEF]`
+  Filter structures based on covalent radius. Filtering is disabled by default.
+  When enabled, structures with bonds shorter than `COEF ×` the covalent radius are
+  written to `remove_by_bond_structures.xyz`. If no coefficient is provided,
+  it defaults to `0.6`.
+- `--pca, -pca`
   Use PCA for decomposition.
-- `--umap, -umap`  
+- `--umap, -umap`
   Use UMAP for decomposition.
 - `-o, --out`  
   Output file for selected structures. Default: `./selected.xyz`.
-- **SOAP Parameters:**  
-  - `-r, --r_cut`  
+- **SOAP Parameters:**
+  - `-r, --r_cut`
     Cutoff for local region (Å). Default: `6`.
-  - `-n, --n_max`  
+  - `-n, --n_max`
     Number of radial basis functions. Default: `8`.
-  - `-l, --l_max`  
+  - `-l, --l_max`
     Maximum degree of spherical harmonics. Default: `6`.
 ## Output
+Selected structures are saved to the file specified by `--out`
+(`./selected.xyz` by default). If `--filter` is provided, structures that
+violate the bond-length criterion are additionally written to
+`remove_by_bond_structures.xyz`.
+
+## Example
+Select up to 100 structures from a trajectory while filtering short
+bonds and save the results to `selected.xyz`:
+
+```bash
+NepTrain select trajectory.xyz -max 100 -f -o selected.xyz
+```

--- a/docs/source/command/train.md
+++ b/docs/source/command/train.md
@@ -4,7 +4,7 @@ Performs automatic training for NEP.
 ## Input Parameters
 
 :::{important}
-- You should use `NepTrain init` to generate `job.yaml`, and then use `NepTrain train job.yaml` to start the training task.  
+- You should use `NepTrain init <type>` to generate `job.yaml`, and then use `NepTrain train job.yaml` to start the training task.
 
 - After the program runs, a `restart.yaml` file will be generated. To continue training, you can use `NepTrain train restart.yaml`.
 ::: 
@@ -13,32 +13,31 @@ Performs automatic training for NEP.
 NepTrain train <config_path>
 ```
 
-**Options:**  
-- `<config_path>`  
+**Options:**
+- `<config_path>`
   Path to configuration file, such as `job.yaml`.
- 
- 
+## Output
+During training, intermediate data and the resulting potential are
+written to the working directory. A `restart.yaml` file is created after
+each iteration, allowing you to resume the workflow with
+`NepTrain train restart.yaml`.
 
-
- 
 ## Example
  
 ### 初始化操作
-在命令行输入`NepTrain init`产生`job.yaml`，包括工作流中的所有控制参数，可修改。
+在命令行输入`NepTrain init slurm`产生`job.yaml`，包括工作流中的所有控制参数，可修改。
 将会产生一个job.yaml文件，打开这个文件，里边将会显示默认的执行参数以及对每个参数的解释，
 在首次运行时，你可能需要逐行对参数进行设置，在以后运行时，你可以复制这个job.yaml文件到以后运行的工作目录作为训练的模板文件。
 :::{tip}
-如果您拷贝之前修改后的job.yaml。如果涉及版本变化，可以拷贝到工作路径，后执行`NepTrain init`。会将新加入的参数同步过来！
+如果您拷贝之前修改后的job.yaml。如果涉及版本变化，可以拷贝到工作路径，后执行`NepTrain init slurm`。会将新加入的参数同步过来！
 :::
  
 ### 开始训练
 在登陆节点的终端执行一下命令
 ```shell
-neptrain train job.yaml
-
+NepTrain train job.yaml
 ```
 后台运行
 ```shell
-nohup neptrain train job.yaml &
-
+nohup NepTrain train job.yaml &
 ```

--- a/docs/source/example/CsPbI3.md
+++ b/docs/source/example/CsPbI3.md
@@ -152,12 +152,10 @@ All template files can be saved by yourself. And all template files can be saved
 :::
 First, we use the following command to initialize
 ```shell
-NepTrain init
+NepTrain init slurm
 <!-- Output is as follows: -->
 [2024-12-29 10:08:27.298365] --  For existing files, we choose to skip; if you need to forcibly generate and overwrite, please use -f or --force.
 [2024-12-29 10:08:27.302688] --  Create the directory ./structure, please place the expanded structures that need to run MD into this folder!
-[2024-12-29 10:08:27.312968] --  Please check the queue information and environment settings in sub_vasp.sh!
-[2024-12-29 10:08:27.317307] --  Please check the queue information and environment settings in sub_gpu.sh!
 [2024-12-29 10:08:27.320868] --  You need to check and modify the vasp_job and vasp.cpu_core in the job.yaml file.
 [2024-12-29 10:08:27.321411] --  You also need to check and modify the settings for GPUMD active learning in job.yaml!
 [2024-12-29 10:08:27.336706] --  Detected that there is no train.xyz in the current directory; please check the directory structure!
@@ -175,35 +173,7 @@ Let's take a look at the current directory:
 ├── run.in
 ├── structure/
 │   └── CsPbI3.vasp
-├── sub_gpu.sh
-├── sub_vasp.sh
 └── train.xyz
-```
-### Modify Submission Scripts
-The sub_gpu.sh is the script for submitting NEP and GPUMD, and the sub_vasp.sh is for submitting VASP.
-Here we only need to modify the queue information and the commands for initializing the environment.
-After modification, it is as follows:
-```shell
-#! /bin/bash
-#SBATCH --job-name=NepTrain
-#SBATCH --nodes=1
-#SBATCH --partition=cpu
-#SBATCH --ntasks-per-node=64 
-#You can place some environment loading commands here.
-source ~/.bashrc
-conda activate NepTrain
-$@ 
-```
-```shell
-#! /bin/bash
-#SBATCH --job-name=NepTrain-gpu
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
-#SBATCH --partition=gpu
-#SBATCH --gres=gpu:1
-source ~/.bashrc
-conda activate NepTrain
-$@
 ```
 ### Modify MD Template [Optional]
 The default run.in  is for npt, and generally, only the `ensemble` needs to be modified, the program will automatically replace the temperature.
@@ -217,7 +187,7 @@ We will not explain each parameter in detail here, only showing how to modify ac
 
 #### VASP Calculation Details
 :::{tip}
-`cpu_core` should be unified with the number of cores applied for in `sub_vasp.sh`.
+`cpu_core` should match the number of CPU cores requested for VASP jobs on your cluster.
 :::
 To accelerate single-point energy calculations, we set the number of tasks through `vasp_job`, and the program will divide the tasks according to this number.
 This depends on your own computational resources.

--- a/src/NepTrain/core/template.py
+++ b/src/NepTrain/core/template.py
@@ -8,52 +8,8 @@ import os.path
 from ase.io import read as ase_read
 from ruamel.yaml import YAML
 
-from NepTrain import module_path, utils,__version__
+from NepTrain import module_path, utils, __version__
 from .utils import check_env
-
-
-def create_vasp(force):
-    if   os.path.exists("./sub_vasp.sh") and not force:
-        return
-    utils.print_warning("Please check the queue information and environment settings in sub_vasp.sh!")
-
-    sub_vasp="""#! /bin/bash
-#SBATCH --job-name=NepTrain
-#SBATCH --nodes=1
-#SBATCH --partition=cpu
-#SBATCH --ntasks-per-node=64
-#You can place some environment loading commands here.
-
-
-
-#eg conda activate NepTrain
-
-$@ 
-
-#NepTrain vasp demo.xyz -np 64 --directory ./cache -g --incar=./INCAR --kpoints 35 -o ./result/result.xyz 
-"""
-
-    with open("./sub_vasp.sh", "w",encoding="utf8") as f:
-        f.write(sub_vasp)
-
-
-def create_nep(force):
-    if os.path.exists("./sub_gpu.sh") and not force:
-        return
-    utils.print_warning("Please check the queue information and environment settings in sub_gpu.sh!")
-
-    sub_vasp = """#! /bin/bash
-#SBATCH --job-name=NepTrain-gpu
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
-#SBATCH --partition=gpu-a800
-#SBATCH --gres=gpu:1
-#You can place some environment loading commands here.
-
- 
-$@ """
-    with open("./sub_gpu.sh", "w", encoding="utf8") as f:
-        f.write(sub_vasp)
 
 def get_job_config(job_type):
     with open(os.path.join(module_path, "core/train/_template/job.yaml"), "r", encoding="utf8") as f:
@@ -71,8 +27,6 @@ def init_template(argparse):
         os.mkdir("./structure")
         utils.print_tip("Create the directory ./structure, please place the expanded structures that need to run MD into this folder!" )
     check_env()
-    # create_vasp(argparse.force)
-    # create_nep(argparse.force)
     if not os.path.exists("./job.yaml") or argparse.force:
         utils.print_tip("You need to check and modify the vasp_job and vasp.cpu_core in the job.yaml file.")
         utils.print_warning("You also need to check and modify the settings for GPUMD active learning in job.yaml!")


### PR DESCRIPTION
## Summary
- document how perturb writes results and add example invocation
- expand select command docs with filter option, output description, and usage sample
- detail NEP and train command outputs and restart behavior
- note how to edit generated templates in `init`
- remove deprecated `sub_gpu.sh` and `sub_vasp.sh` templates from init workflow and examples
- document scheduler type argument, fix select defaults, drop gpumd filter, and add nep flag aliases
- add comprehensive guide for `dft` command including VASP/ABACUS options

## Testing
- `pip install -r docs/requirements.txt`
- `sphinx-build -b html docs/source docs/_build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689466262094832e988f361f44fdf946