### PR TITLE
docs: translate Chinese sections

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-# MANIFEST.in 文件
+# MANIFEST.in file
 
 
 recursive-include src *

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,5 +1,5 @@
 pre {
-    max-height: 400px;  /* 设置最大高度 */
-    overflow-y: auto;   /* 启用垂直滚动条 */
+    max-height: 400px;  /* Set maximum height */
+    overflow-y: auto;   /* Enable vertical scrollbar */
 
 }

--- a/docs/source/command/init.md
+++ b/docs/source/command/init.md
@@ -26,19 +26,25 @@ These output files serve as inputs for the `train` command. Detailed modificatio
 
 - `structure/`
   This folder must contain the structures required for active learning. Multiple structures can be included, and the file format should be either `.xyz` or `.vasp`.
-### 可选的模板文件
-- INCAR  or INPUT
-用户可以通过`INCAR` or `INPUT`文件指定单点能的计算细节。如果没有指定则使用默认。默认INCAR细节详见[INCAR](vasp.md)
-- nep.in
-如果没有指定该文件，会根据训练集自动判断元素种类，生成最简的nep.in。如果需要修改训练超参数，请自行创建该文件。
-  最简的nep.in如下
+### 可选的模板文件 / Optional Template Files
+- INCAR or INPUT  
+  用户可以通过 `INCAR` 或 `INPUT` 文件指定单点能计算的细节。如果没有提供，将使用默认设置。默认的 INCAR 参数详见 [INCAR](vasp.md)。  
+  Users can specify details of single-point energy calculations through the `INCAR` or `INPUT` file. If not provided, the defaults are used. For the default INCAR settings, see [INCAR](vasp.md).
+- nep.in  
+  如果没有提供该文件，程序会根据训练集自动识别元素种类，并生成最简的 `nep.in`。若需修改训练超参数，请自行创建此文件。  
+  If this file is absent, the program automatically detects element types from the training set and generates a minimal `nep.in`. Create this file manually to modify training hyperparameters.  
+  最简的 `nep.in` 如下  
+  The minimal `nep.in` is:
     ```text
       generation     100000
       type     3 I Cs Pb
-      ```
-## 文件修改
-生成的模板文件可以根据实际环境进行修改：
+    ```
+## 文件修改 / File Modification
+生成的模板文件可以根据实际环境进行调整：  
+The generated template files can be adapted to your environment:
 
-- 根据训练需求编辑 `job.yaml` 中的参数。
-- 如需自定义训练超参数，可手动修改或创建 `nep.in`。
+- 根据训练需求编辑 `job.yaml` 中的参数。  
+  Edit the parameters in `job.yaml` according to your training requirements.
+- 如需自定义训练超参数，可手动修改或创建 `nep.in`。  
+  To customize training hyperparameters, manually modify or create `nep.in`.
 

--- a/docs/source/command/train.md
+++ b/docs/source/command/train.md
@@ -23,21 +23,25 @@ each iteration, allowing you to resume the workflow with
 `NepTrain train restart.yaml`.
 
 ## Example
- 
-### 初始化操作
-在命令行输入`NepTrain init slurm`产生`job.yaml`，包括工作流中的所有控制参数，可修改。
-将会产生一个job.yaml文件，打开这个文件，里边将会显示默认的执行参数以及对每个参数的解释，
-在首次运行时，你可能需要逐行对参数进行设置，在以后运行时，你可以复制这个job.yaml文件到以后运行的工作目录作为训练的模板文件。
+
+### 初始化操作 / Initialization
+在命令行输入 `NepTrain init slurm` 生成 `job.yaml`，其中包含工作流的所有可修改控制参数。  
+Run `NepTrain init slurm` on the command line to generate `job.yaml`, which contains all modifiable control parameters of the workflow.  
+会产生一个 `job.yaml` 文件，打开后可以看到默认的执行参数及其解释。首次运行时，可逐行设置参数；之后可复制该文件作为训练模板。  
+The command produces a `job.yaml` file showing default execution parameters and their explanations. Set the parameters line by line on the first run, and later reuse the file as a template for future training.
 :::{tip}
-如果您拷贝之前修改后的job.yaml。如果涉及版本变化，可以拷贝到工作路径，后执行`NepTrain init slurm`。会将新加入的参数同步过来！
+如果您复制了之前修改过的 `job.yaml`，在版本更新时可以将其复制到工作目录并运行 `NepTrain init slurm`，以同步新增参数。  
+If you copy a previously modified `job.yaml`, you can place it in the working directory and run `NepTrain init slurm` again to synchronize any newly added parameters during version updates.
 :::
- 
-### 开始训练
-在登陆节点的终端执行一下命令
+
+### 开始训练 / Start Training
+在登录节点的终端执行以下命令：  
+Run the following command on the login node:
 ```shell
 NepTrain train job.yaml
 ```
-后台运行
+后台运行：  
+To run in the background:
 ```shell
 nohup NepTrain train job.yaml &
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ myst_enable_extensions = [
 ]
 
 templates_path = ['_templates']
-# locale_dirs = ['docs/locales']  # 语言文件目录
+# locale_dirs = ['docs/locales']  # directory for language files
 language = 'en'
 
 
@@ -53,7 +53,7 @@ html_context = {
     "author_name": author,
 }
 html_css_files = [
-    'css/custom.css',  # 你可以在这里指定你的自定义 CSS 文件
+    'css/custom.css',  # specify your custom CSS file here
 ]
 
 source_suffix = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [{ name = "Chen Cheng bing", email = "1747193328@qq.com" }]
 dynamic = ["version"]
 
 description = """
-NEP自动训练
+Automatic training for NEP
 """
 readme = "README.md"
 requires-python = ">=3.8,<3.13"
@@ -68,11 +68,11 @@ include-package-data = false
 where = ["src"]
 include = ["NepTrain", "NepTrain.*"]
 [tool.setuptools_scm]
-# 可选配置（根据需求调整）：
-# - 指定 Git 标签格式（默认匹配 v*）
+# Optional configuration (adjust as needed):
+# - Specify Git tag pattern (matches v* by default)
 tag_regex = "^v(?P<version>[0-9.]+(?:b[0-9]+)?)$"
-# - 启用本地版本号（开发时生成 dev 版本）
-local_scheme = "no-local-version"  # 或 "node-and-date"
+# - Enable local version numbers (generate dev builds during development)
+local_scheme = "no-local-version"  # or "node-and-date"
 
 [tool.setuptools.package-data]
 "NepTrain" = ["config.ini" ]


### PR DESCRIPTION
## Summary
- Add bilingual explanations for optional template files and file modification steps
- Document initialization and training procedures with Chinese and English text
- Replace Chinese comments with English in documentation config and CSS
- Translate packaging metadata comments to English

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689486b28cb0832e849dc2772ef7ce8e