### PR TITLE
Use Node 24 artifact actions in release workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -49,7 +49,7 @@ jobs:
           "$release_cli" --help
           "$release_cli" smoke --profile ordinary --output "$RUNNER_TEMP/neptrain-smoke"
       - name: Store release distributions
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: release-distributions
           path: dist/
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: release-distributions
           path: dist/


### PR DESCRIPTION
发布 v3.0.0 时 GitHub 对 upload/download-artifact@v5 给出 Node 20 弃用告警。本 PR 升级到已验证存在的 v6 标签；actionlint 通过，不改变发行物或发布逻辑。